### PR TITLE
security: enable CSP + remove unused GoDaddy config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -48,15 +48,28 @@ export default defineNuxtConfig({
     defaultLocale: 'en',
   },
 
-  runtimeConfig: {
-    godaddyApiKey: process.env.GODADDY_API_KEY,
-    godaddyApiSecret: process.env.GODADDY_API_SECRET,
-  },
-
   security: {
     headers: {
-      contentSecurityPolicy: false,
+      contentSecurityPolicy: {
+        'default-src': ["'self'"],
+        'script-src': ["'self'", "'unsafe-inline'", 'https://va.vercel-scripts.com'],
+        'style-src': ["'self'", "'unsafe-inline'"],
+        'img-src': ["'self'", 'data:', 'blob:'],
+        'font-src': ["'self'", 'data:'],
+        // Client-side DoH lookups go directly to Cloudflare
+        'connect-src': [
+          "'self'",
+          'https://1.1.1.1',
+          'https://cloudflare-dns.com',
+          'https://va.vercel-scripts.com',
+          'https://vitals.vercel-insights.com',
+        ],
+        'frame-ancestors': ["'none'"],
+        'base-uri': ["'self'"],
+        'form-action': ["'self'"],
+      },
       crossOriginEmbedderPolicy: false,
+      xFrameOptions: 'DENY',
     },
   },
 
@@ -68,7 +81,6 @@ export default defineNuxtConfig({
           interval: 10000,
         },
       },
-      // Add request size limits to prevent memory issues
       cors: true,
       headers: {
         'X-Content-Type-Options': 'nosniff',


### PR DESCRIPTION
## Summary
- Remove unused `GODADDY_API_KEY` / `GODADDY_API_SECRET` from `runtimeConfig`
- Re-enable **Content-Security-Policy** via `nuxt-security`
  - `connect-src` allows Cloudflare DoH (`1.1.1.1`, `cloudflare-dns.com`) + Vercel analytics
  - Scripts/styles keep `'unsafe-inline'` for Nuxt UI compatibility

## Test plan
- [ ] Domain search still works (DoH not blocked by CSP)
- [ ] No CSP errors in browser console for core UI
- [ ] Vercel Analytics still loads if enabled