### PR TITLE
chore(deps): bump Nuxt to ^4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@nuxt/ui": "^4.7.1",
     "@nuxtjs/seo": "5.1.3",
     "@vercel/analytics": "^2.0.1",
-    "nuxt": "^4.4.5"
+    "nuxt": "^4.5.0"
   },
   "devDependencies": {
     "@nuxt/devtools": "4.0.0-alpha.4",


### PR DESCRIPTION
## Dependency Update

Bumps `nuxt` from `^4.4.5` → `^4.5.0`.

Nuxt 4.5.0 includes various fixes, Vite 8 support, and other improvements. Keeps the project on the latest stable minor.

After merge please run `pnpm install` to update the lockfile.